### PR TITLE
yapp.js global install permission fix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ desc "install dependencies using npm"
 task :install do
     check 'npm', 'NPM', 'https://npmjs.org/'
     system 'npm install .'
-    system 'npm install -g git://github.com/FriendCode/yapp.js.git#master'
+    system 'sudo -H npm install -g git://github.com/FriendCode/yapp.js.git#master'
 end
 
 desc "run server"


### PR DESCRIPTION
For certain platforms, such as Arch Linux, `npm -g` requires administrator permissions. Prefixed the command with `sudo -H` to give permissions while still using the user's home directory
