### PR TITLE
[FIX] add the right path to NPM ensure npm is accessed right and update node version

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,12 +33,13 @@ task :install do
     check 'npm', 'NPM', 'https://npmjs.org/'
     system 'npm install .'
 
+    runner = run_exec("npm").chomp
     # Install YappJS os specfic
     case os()
     when :macosx
-        system 'npm install -g git+https://github.com/FriendCode/yapp.js.git#master'
+        system "#{runner} install -g git+https://github.com/FriendCode/yapp.js.git#master"
     when :linux || :unix
-        system 'sudo -H npm install -g git+https://github.com/FriendCode/yapp.js.git#master'
+        system "sudo -H #{runner} install -g git+https://github.com/FriendCode/yapp.js.git#master"
     end
 end
 
@@ -49,6 +50,10 @@ task :run do
 end
 
 task :default => ['build', 'run']
+
+def run_exec(exec)
+  `which #{exec}`
+end
 
 # Check for the existence of an executable.
 def check(exec, name, url)


### PR DESCRIPTION
- Add a full path call when installing yapp, it was failing due to the sudo user unable to find the npm executable.
- Updated the required node engine version from 0.6.x to 0.10.x which is was currently installs from apt. (easier to setup out of the box)
